### PR TITLE
push production images to ECR, ACR, and Artifact Registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,23 +162,5 @@ NATIVE_APP_URL_SCHEME=oauth2app
 # See also .github/.vars.example for non-sensitive variables.
 # -------------------------------------------------------
 
-# ARN of the IAM role for GitHub Actions OIDC (AWS).
-AWS_IAM_ROLE_ARN=arn:aws:iam::123456789012:role/github-actions
-
-# Azure AD application (service principal) client ID.
-ARM_CLIENT_ID=00000000-0000-0000-0000-000000000000
-
-# Azure AD tenant ID.
-ARM_TENANT_ID=00000000-0000-0000-0000-000000000000
-
-# Azure subscription ID.
-ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
-
-# GCP Workload Identity Federation provider resource name.
-GCP_WORKLOAD_IDENTITY_PROVIDER=projects/123456789/locations/global/workloadIdentityPools/github/providers/github
-
-# GCP service account email for GitHub Actions.
-GCP_SERVICE_ACCOUNT=github-actions@my-gcp-project.iam.gserviceaccount.com
-
 # Database password for ephemeral Cloud SQL / RDS / PostgreSQL Flexible Server.
 TF_VAR_DATABASE_PASSWORD=change-me-database-password

--- a/.github/.vars.example
+++ b/.github/.vars.example
@@ -3,25 +3,68 @@
 #   gh variable set --env-file .github/.vars
 
 # AWS
+
+# IAM role ARN with GitHub OIDC trust policy (used for IaC and production image push).
+AWS_IAM_ROLE_ARN=arn:aws:iam::123456789012:role/github-actions-iac
+
+# S3 bucket name for Terraform state storage.
 AWS_TF_STATE_BUCKET=my-terraform-state
+
+# AWS region where the S3 state bucket is located.
 AWS_TF_STATE_REGION=us-east-1
 
 # Azure
+
+# Resource group that contains the Terraform state storage account.
 AZURE_TF_STATE_RESOURCE_GROUP=terraform-state-rg
+
+# Storage account name for Terraform state (must be globally unique).
 AZURE_TF_STATE_STORAGE_ACCOUNT=myterraformstate
+
+# Azure region for the Terraform state storage account.
 AZURE_TF_STATE_LOCATION=eastus
+
+# Azure Container Registry name (used by persistent layer and production image push).
 AZURE_CONTAINER_REGISTRY_NAME=myregistry
 
+# Azure AD application (service principal) client ID for OIDC authentication.
+ARM_CLIENT_ID=00000000-0000-0000-0000-000000000000
+
+# Azure AD tenant ID.
+ARM_TENANT_ID=00000000-0000-0000-0000-000000000000
+
+# Azure subscription ID.
+ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
+
 # Google Cloud
+
+# GCS bucket name for Terraform state storage.
 GCP_TF_STATE_BUCKET=my-terraform-state
+
+# GCS bucket location (e.g. us, eu, asia).
 GCP_TF_STATE_LOCATION=us
+
+# GCP project ID (used for IaC and production image push).
 GCP_PROJECT_ID=my-gcp-project
 
+# GCP region for Artifact Registry (optional, defaults to us-central1).
+GCP_REGION=us-central1
+
+# Workload Identity Federation provider resource name for OIDC authentication.
+GCP_WORKLOAD_IDENTITY_PROVIDER=projects/123456789/locations/global/workloadIdentityPools/github/providers/github
+
+# GCP service account email for GitHub Actions to impersonate.
+GCP_SERVICE_ACCOUNT=github-actions@my-gcp-project.iam.gserviceaccount.com
+
 # App
+
+# Unique prefix for all cloud resource names (e.g. ECR repos, resource groups, Cloud Run services).
 TF_VAR_APP_UNIQUE_ID=oauth2-app
 
-# DNS (service URLs are derived: https://{web,backend}.{cdp}.{app_unique_id}.{domain})
+# Base domain for DNS and service URLs.
+# Service URLs are derived as: https://{web,backend}.{cdp}.{app_unique_id}.{domain}
 TF_VAR_BASE_DOMAIN_NAME=example.com
 
-# Ephemeral layer — container image tag (registry URL derived from persistent layer outputs)
+# Container image tag for the ephemeral layer (optional, defaults to latest).
+# Registry URLs are derived from the persistent layer's Terraform outputs.
 # TF_VAR_IMAGE_TAG=latest

--- a/.github/.vars.example
+++ b/.github/.vars.example
@@ -24,9 +24,6 @@ AZURE_TF_STATE_STORAGE_ACCOUNT=myterraformstate
 # Azure region for the Terraform state storage account.
 AZURE_TF_STATE_LOCATION=eastus
 
-# Azure Container Registry name (used by persistent layer and production image push).
-AZURE_CONTAINER_REGISTRY_NAME=myregistry
-
 # Azure AD application (service principal) client ID for OIDC authentication.
 ARM_CLIENT_ID=00000000-0000-0000-0000-000000000000
 
@@ -47,8 +44,11 @@ GCP_TF_STATE_LOCATION=us
 # GCP project ID (used for IaC and production image push).
 GCP_PROJECT_ID=my-gcp-project
 
-# GCP region for Artifact Registry (optional, defaults to us-central1).
+# GCP region (optional, defaults to us-central1).
 GCP_REGION=us-central1
+
+# GCP zone (optional, defaults to us-central1-a).
+GCP_ZONE=us-central1-a
 
 # Workload Identity Federation provider resource name for OIDC authentication.
 GCP_WORKLOAD_IDENTITY_PROVIDER=projects/123456789/locations/global/workloadIdentityPools/github/providers/github

--- a/.github/workflows/backend.production-build.yaml
+++ b/.github/workflows/backend.production-build.yaml
@@ -6,12 +6,18 @@ on:
     paths:
       - 'backend/**'
       - 'Dockerfiles.d/backend-production/**'
+      - 'iac/aws/*'
+      - 'iac/azure/*'
+      - 'iac/google/*'
       - '.github/workflows/backend.production-build.yaml'
   pull_request:
     branches: [main]
     paths:
       - 'backend/**'
       - 'Dockerfiles.d/backend-production/**'
+      - 'iac/aws/*'
+      - 'iac/azure/*'
+      - 'iac/google/*'
       - '.github/workflows/backend.production-build.yaml'
   workflow_dispatch: {}
 
@@ -51,14 +57,28 @@ jobs:
 
       - name: Log in to Amazon ECR
         if: vars.AWS_IAM_ROLE_ARN != ''
-        id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Setup Terraform (AWS)
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get ECR repository URL from Terraform
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        id: ecr
+        run: |
+          terraform -chdir=iac/aws init \
+            -backend-config="bucket=${{ vars.AWS_TF_STATE_BUCKET }}" \
+            -backend-config="region=${{ vars.AWS_TF_STATE_REGION }}"
+          echo "repo=$(terraform -chdir=iac/aws output -raw ecr_backend_repository_url)" >> "$GITHUB_OUTPUT"
 
       - name: Build ECR tags
         id: ecr-tags
         if: vars.AWS_IAM_ROLE_ARN != ''
         run: |
-          repo="${{ steps.ecr-login.outputs.registry }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}-backend"
+          repo="${{ steps.ecr.outputs.repo }}"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"
@@ -75,15 +95,38 @@ jobs:
           tenant-id: ${{ vars.ARM_TENANT_ID }}
           subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform (Azure)
+        if: vars.ARM_CLIENT_ID != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get ACR login server from Terraform
+        if: vars.ARM_CLIENT_ID != ''
+        id: acr
+        env:
+          ARM_USE_OIDC: "true"
+          ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+        run: |
+          terraform -chdir=iac/azure init \
+            -backend-config="resource_group_name=${{ vars.AZURE_TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.AZURE_TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=tfstate"
+          login_server=$(terraform -chdir=iac/azure output -raw container_registry_login_server)
+          echo "login_server=$login_server" >> "$GITHUB_OUTPUT"
+          echo "name=${login_server%%.*}" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Azure Container Registry
         if: vars.ARM_CLIENT_ID != ''
-        run: az acr login --name "${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}"
+        run: az acr login --name "${{ steps.acr.outputs.name }}"
 
       - name: Build ACR tags
         id: acr-tags
         if: vars.ARM_CLIENT_ID != ''
         run: |
-          repo="${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}.azurecr.io/backend"
+          repo="${{ steps.acr.outputs.login_server }}/backend"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"
@@ -103,15 +146,32 @@ jobs:
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Setup Terraform (Google)
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get Artifact Registry repository from Terraform
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        id: gar
+        run: |
+          terraform -chdir=iac/google init \
+            -backend-config="bucket=${{ vars.GCP_TF_STATE_BUCKET }}"
+          repo=$(terraform -chdir=iac/google output -raw artifact_registry_repository)
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          registry_host="${repo%%/*}"
+          echo "registry_host=$registry_host" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Artifact Registry
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
-        run: gcloud auth configure-docker "${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev"
+        run: gcloud auth configure-docker "${{ steps.gar.outputs.registry_host }}"
 
       - name: Build Artifact Registry tags
         id: gar-tags
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
         run: |
-          repo="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}/backend"
+          repo="${{ steps.gar.outputs.repo }}/backend"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"

--- a/.github/workflows/backend.production-build.yaml
+++ b/.github/workflows/backend.production-build.yaml
@@ -41,6 +41,85 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- AWS ECR ---
+      - name: Configure AWS credentials
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_TF_STATE_REGION || 'us-east-1' }}
+
+      - name: Log in to Amazon ECR
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build ECR tags
+        id: ecr-tags
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        run: |
+          repo="${{ steps.ecr-login.outputs.registry }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}-backend"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Azure ACR ---
+      - name: Authenticate to Azure
+        if: vars.ARM_CLIENT_ID != ''
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        if: vars.ARM_CLIENT_ID != ''
+        run: az acr login --name "${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}"
+
+      - name: Build ACR tags
+        id: acr-tags
+        if: vars.ARM_CLIENT_ID != ''
+        run: |
+          repo="${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}.azurecr.io/backend"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Google Artifact Registry ---
+      - name: Authenticate to GCP
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to Artifact Registry
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        run: gcloud auth configure-docker "${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev"
+
+      - name: Build Artifact Registry tags
+        id: gar-tags
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        run: |
+          repo="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}/backend"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Build and push ---
       - name: Build and push backend image
         id: build
         uses: docker/build-push-action@v4
@@ -51,6 +130,9 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/backend:latest
             ghcr.io/${{ github.repository }}/backend:${{ github.sha }}
+            ${{ steps.ecr-tags.outputs.tags }}
+            ${{ steps.acr-tags.outputs.tags }}
+            ${{ steps.gar-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/iac.ephemeral.yaml
+++ b/.github/workflows/iac.ephemeral.yaml
@@ -111,8 +111,9 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: |
           set +e
@@ -156,6 +157,8 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
@@ -174,6 +177,8 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
@@ -185,6 +190,8 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}

--- a/.github/workflows/iac.ephemeral.yaml
+++ b/.github/workflows/iac.ephemeral.yaml
@@ -38,31 +38,31 @@ jobs:
         if: inputs.provider == 'aws'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Authenticate to Azure
         if: inputs.provider == 'azure'
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
 
       - name: Set Azure OIDC environment for Terraform
         if: inputs.provider == 'azure'
         run: |
           echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
-          echo "ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }}" >> $GITHUB_ENV
-          echo "ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }}" >> $GITHUB_ENV
-          echo "ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+          echo "ARM_CLIENT_ID=${{ vars.ARM_CLIENT_ID }}" >> $GITHUB_ENV
+          echo "ARM_TENANT_ID=${{ vars.ARM_TENANT_ID }}" >> $GITHUB_ENV
+          echo "ARM_SUBSCRIPTION_ID=${{ vars.ARM_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
 
       - name: Authenticate to GCP
         if: inputs.provider == 'google'
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Bootstrap S3 tfstate backend
         if: inputs.provider == 'aws'
@@ -111,7 +111,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: |
@@ -156,7 +156,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
           TF_VAR_image_tag: ${{ vars.TF_VAR_IMAGE_TAG || 'latest' }}
@@ -174,7 +174,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
           TF_VAR_image_tag: ${{ vars.TF_VAR_IMAGE_TAG || 'latest' }}
@@ -185,7 +185,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
           TF_VAR_database_password: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
           TF_VAR_image_tag: ${{ vars.TF_VAR_IMAGE_TAG || 'latest' }}

--- a/.github/workflows/iac.yaml
+++ b/.github/workflows/iac.yaml
@@ -81,31 +81,31 @@ jobs:
         if: matrix.provider == 'aws'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Authenticate to Azure
         if: matrix.provider == 'azure'
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
 
       - name: Set Azure OIDC environment for Terraform
         if: matrix.provider == 'azure'
         run: |
           echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
-          echo "ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }}" >> $GITHUB_ENV
-          echo "ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }}" >> $GITHUB_ENV
-          echo "ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+          echo "ARM_CLIENT_ID=${{ vars.ARM_CLIENT_ID }}" >> $GITHUB_ENV
+          echo "ARM_TENANT_ID=${{ vars.ARM_TENANT_ID }}" >> $GITHUB_ENV
+          echo "ARM_SUBSCRIPTION_ID=${{ vars.ARM_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
 
       - name: Authenticate to GCP
         if: matrix.provider == 'google'
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Bootstrap S3 tfstate backend
         if: matrix.provider == 'aws'
@@ -157,7 +157,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: |
@@ -174,7 +174,7 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
-          TF_VAR_azure_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
           TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: terraform -chdir=iac/${{ matrix.provider }} apply -auto-approve -input=false

--- a/.github/workflows/iac.yaml
+++ b/.github/workflows/iac.yaml
@@ -157,8 +157,9 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: |
           terraform -chdir=iac/${{ matrix.provider }} plan -no-color -input=false 2>&1 | tee plan-output.txt
@@ -174,7 +175,8 @@ jobs:
         env:
           TF_VAR_app_unique_id: ${{ vars.TF_VAR_APP_UNIQUE_ID }}
           TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          TF_VAR_gcp_region: ${{ vars.GCP_REGION }}
+          TF_VAR_gcp_zone: ${{ vars.GCP_ZONE }}
           TF_VAR_azure_subscription_id: ${{ vars.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_azure_container_registry_name: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
           TF_VAR_base_domain_name: ${{ vars.TF_VAR_BASE_DOMAIN_NAME }}
         run: terraform -chdir=iac/${{ matrix.provider }} apply -auto-approve -input=false

--- a/.github/workflows/web.production-build.yaml
+++ b/.github/workflows/web.production-build.yaml
@@ -41,6 +41,85 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- AWS ECR ---
+      - name: Configure AWS credentials
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_TF_STATE_REGION || 'us-east-1' }}
+
+      - name: Log in to Amazon ECR
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build ECR tags
+        id: ecr-tags
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        run: |
+          repo="${{ steps.ecr-login.outputs.registry }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}-web"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Azure ACR ---
+      - name: Authenticate to Azure
+        if: vars.ARM_CLIENT_ID != ''
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.ARM_CLIENT_ID }}
+          tenant-id: ${{ vars.ARM_TENANT_ID }}
+          subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        if: vars.ARM_CLIENT_ID != ''
+        run: az acr login --name "${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}"
+
+      - name: Build ACR tags
+        id: acr-tags
+        if: vars.ARM_CLIENT_ID != ''
+        run: |
+          repo="${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}.azurecr.io/web"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Google Artifact Registry ---
+      - name: Authenticate to GCP
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to Artifact Registry
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        run: gcloud auth configure-docker "${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev"
+
+      - name: Build Artifact Registry tags
+        id: gar-tags
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        run: |
+          repo="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}/web"
+          {
+            echo "tags<<EOF"
+            echo "${repo}:latest"
+            echo "${repo}:${{ github.sha }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Build and push ---
       - name: Build and push web image
         id: build
         uses: docker/build-push-action@v4
@@ -51,6 +130,9 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/web:latest
             ghcr.io/${{ github.repository }}/web:${{ github.sha }}
+            ${{ steps.ecr-tags.outputs.tags }}
+            ${{ steps.acr-tags.outputs.tags }}
+            ${{ steps.gar-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/web.production-build.yaml
+++ b/.github/workflows/web.production-build.yaml
@@ -6,12 +6,18 @@ on:
     paths:
       - 'web/app/**'
       - 'Dockerfiles.d/web-production/**'
+      - 'iac/aws/*'
+      - 'iac/azure/*'
+      - 'iac/google/*'
       - '.github/workflows/web.production-build.yaml'
   pull_request:
     branches: [main]
     paths:
       - 'web/app/**'
       - 'Dockerfiles.d/web-production/**'
+      - 'iac/aws/*'
+      - 'iac/azure/*'
+      - 'iac/google/*'
       - '.github/workflows/web.production-build.yaml'
   workflow_dispatch: {}
 
@@ -51,14 +57,28 @@ jobs:
 
       - name: Log in to Amazon ECR
         if: vars.AWS_IAM_ROLE_ARN != ''
-        id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Setup Terraform (AWS)
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get ECR repository URL from Terraform
+        if: vars.AWS_IAM_ROLE_ARN != ''
+        id: ecr
+        run: |
+          terraform -chdir=iac/aws init \
+            -backend-config="bucket=${{ vars.AWS_TF_STATE_BUCKET }}" \
+            -backend-config="region=${{ vars.AWS_TF_STATE_REGION }}"
+          echo "repo=$(terraform -chdir=iac/aws output -raw ecr_web_repository_url)" >> "$GITHUB_OUTPUT"
 
       - name: Build ECR tags
         id: ecr-tags
         if: vars.AWS_IAM_ROLE_ARN != ''
         run: |
-          repo="${{ steps.ecr-login.outputs.registry }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}-web"
+          repo="${{ steps.ecr.outputs.repo }}"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"
@@ -75,15 +95,38 @@ jobs:
           tenant-id: ${{ vars.ARM_TENANT_ID }}
           subscription-id: ${{ vars.ARM_SUBSCRIPTION_ID }}
 
+      - name: Setup Terraform (Azure)
+        if: vars.ARM_CLIENT_ID != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get ACR login server from Terraform
+        if: vars.ARM_CLIENT_ID != ''
+        id: acr
+        env:
+          ARM_USE_OIDC: "true"
+          ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+        run: |
+          terraform -chdir=iac/azure init \
+            -backend-config="resource_group_name=${{ vars.AZURE_TF_STATE_RESOURCE_GROUP }}" \
+            -backend-config="storage_account_name=${{ vars.AZURE_TF_STATE_STORAGE_ACCOUNT }}" \
+            -backend-config="container_name=tfstate"
+          login_server=$(terraform -chdir=iac/azure output -raw container_registry_login_server)
+          echo "login_server=$login_server" >> "$GITHUB_OUTPUT"
+          echo "name=${login_server%%.*}" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Azure Container Registry
         if: vars.ARM_CLIENT_ID != ''
-        run: az acr login --name "${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}"
+        run: az acr login --name "${{ steps.acr.outputs.name }}"
 
       - name: Build ACR tags
         id: acr-tags
         if: vars.ARM_CLIENT_ID != ''
         run: |
-          repo="${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}.azurecr.io/web"
+          repo="${{ steps.acr.outputs.login_server }}/web"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"
@@ -103,15 +146,32 @@ jobs:
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Setup Terraform (Google)
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Get Artifact Registry repository from Terraform
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        id: gar
+        run: |
+          terraform -chdir=iac/google init \
+            -backend-config="bucket=${{ vars.GCP_TF_STATE_BUCKET }}"
+          repo=$(terraform -chdir=iac/google output -raw artifact_registry_repository)
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          registry_host="${repo%%/*}"
+          echo "registry_host=$registry_host" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Artifact Registry
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
-        run: gcloud auth configure-docker "${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev"
+        run: gcloud auth configure-docker "${{ steps.gar.outputs.registry_host }}"
 
       - name: Build Artifact Registry tags
         id: gar-tags
         if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
         run: |
-          repo="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.TF_VAR_APP_UNIQUE_ID || 'oauth2-app' }}/web"
+          repo="${{ steps.gar.outputs.repo }}/web"
           {
             echo "tags<<EOF"
             echo "${repo}:latest"

--- a/iac/azure/container-registry.tf
+++ b/iac/azure/container-registry.tf
@@ -1,5 +1,10 @@
+locals {
+  # ACR name must be alphanumeric only — strip non-alphanumeric chars from app_unique_id
+  acr_name = join("", regexall("[a-zA-Z0-9]+", var.app_unique_id))
+}
+
 resource "azurerm_container_registry" "main" {
-  name                = var.azure_container_registry_name
+  name                = local.acr_name
   location            = azurerm_resource_group.persistent.location
   resource_group_name = azurerm_resource_group.persistent.name
   sku                 = "Basic"

--- a/iac/azure/terraform.tfvars.example
+++ b/iac/azure/terraform.tfvars.example
@@ -3,8 +3,5 @@ app_unique_id = "oauth2-app"
 azure_subscription_id = "your-azure-subscription-id"
 azure_location        = "eastus"
 
-# Container Registry (must be globally unique, alphanumeric only)
-azure_container_registry_name = "oauth2appacr"
-
 # DNS
 base_domain_name = "example.com"

--- a/iac/azure/variables.tf
+++ b/iac/azure/variables.tf
@@ -16,12 +16,6 @@ variable "azure_location" {
   default     = "eastus"
 }
 
-variable "azure_container_registry_name" {
-  description = "Azure Container Registry name (must be globally unique, alphanumeric only)"
-  type        = string
-  default     = ""
-}
-
 variable "base_domain_name" {
   description = "Base domain name for DNS zone (e.g. example.com). Zone: azure.{app_unique_id}.{base_domain_name}"
   type        = string

--- a/iac/google/artifact-registry.tf
+++ b/iac/google/artifact-registry.tf
@@ -1,6 +1,6 @@
 resource "google_artifact_registry_repository" "docker" {
   location      = var.gcp_region
-  repository_id = var.artifact_registry_repository_id
+  repository_id = var.app_unique_id
   format        = "DOCKER"
 
   depends_on = [google_project_service.apis]

--- a/iac/google/ephemeral/remote-state.tf
+++ b/iac/google/ephemeral/remote-state.tf
@@ -11,6 +11,8 @@ data "terraform_remote_state" "persistent" {
 
 locals {
   persistent       = data.terraform_remote_state.persistent.outputs
+  gcp_region       = local.persistent.gcp_region
+  gcp_zone         = local.persistent.gcp_zone
   frontend_url     = "https://web.google.${var.app_unique_id}.${var.base_domain_name}"
   backend_base_url = "https://backend.google.${var.app_unique_id}.${var.base_domain_name}"
 }

--- a/iac/google/ephemeral/variables.tf
+++ b/iac/google/ephemeral/variables.tf
@@ -9,18 +9,6 @@ variable "gcp_project_id" {
   type        = string
 }
 
-variable "gcp_region" {
-  description = "GCP region"
-  type        = string
-  default     = "us-central1"
-}
-
-variable "gcp_zone" {
-  description = "GCP zone"
-  type        = string
-  default     = "us-central1-a"
-}
-
 # -----------------------------------------------------------------------------
 # Container image tag
 # The registry URL is derived from the persistent layer's Artifact Registry output.

--- a/iac/google/ephemeral/versions.tf
+++ b/iac/google/ephemeral/versions.tf
@@ -24,6 +24,6 @@ terraform {
 
 provider "google" {
   project = var.gcp_project_id
-  region  = var.gcp_region
-  zone    = var.gcp_zone
+  region  = local.gcp_region
+  zone    = local.gcp_zone
 }

--- a/iac/google/outputs.tf
+++ b/iac/google/outputs.tf
@@ -1,3 +1,13 @@
+output "gcp_region" {
+  description = "GCP region"
+  value       = var.gcp_region
+}
+
+output "gcp_zone" {
+  description = "GCP zone"
+  value       = var.gcp_zone
+}
+
 output "artifact_registry_repository" {
   description = "Artifact Registry repository path for docker push"
   value       = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.docker.repository_id}"

--- a/iac/google/terraform.tfvars.example
+++ b/iac/google/terraform.tfvars.example
@@ -4,8 +4,5 @@ gcp_project_id = "your-gcp-project-id"
 gcp_region     = "us-central1"
 gcp_zone       = "us-central1-a"
 
-# Artifact Registry
-artifact_registry_repository_id = "oauth2-app"
-
 # DNS
 base_domain_name = "example.com"

--- a/iac/google/variables.tf
+++ b/iac/google/variables.tf
@@ -21,12 +21,6 @@ variable "gcp_zone" {
   default     = "us-central1-a"
 }
 
-variable "artifact_registry_repository_id" {
-  description = "Artifact Registry repository ID"
-  type        = string
-  default     = "oauth2-app"
-}
-
 variable "base_domain_name" {
   description = "Base domain name for DNS zone (e.g. example.com). Zone: google.{app_unique_id}.{base_domain_name}"
   type        = string


### PR DESCRIPTION
Extend production build workflow to push images to all three cloud registries alongside GHCR, gated on repository variables. Move non-sensitive OIDC credenatials (IAM role ARN, Azure AD IDs, Google Cloud workload identity) from secrets to vars across IaC workflows.